### PR TITLE
consider "<" before checking if we're in a special

### DIFF
--- a/lib/Tokenizer.js
+++ b/lib/Tokenizer.js
@@ -166,6 +166,9 @@ Tokenizer.prototype._stateText = function(c){
 Tokenizer.prototype._stateBeforeTagName = function(c){
 	if(c === "/"){
 		this._state = BEFORE_CLOSING_TAG_NAME;
+	} else if(c === "<"){
+		this._cbs.ontext(this._getSection());
+		this._sectionStart = this._index;
 	} else if(c === ">" || this._special !== SPECIAL_NONE || whitespace(c)) {
 		this._state = TEXT;
 	} else if(c === "!"){
@@ -174,9 +177,6 @@ Tokenizer.prototype._stateBeforeTagName = function(c){
 	} else if(c === "?"){
 		this._state = IN_PROCESSING_INSTRUCTION;
 		this._sectionStart = this._index + 1;
-	} else if(c === "<"){
-		this._cbs.ontext(this._getSection());
-		this._sectionStart = this._index;
 	} else {
 		this._state = (!this._xmlMode && (c === "s" || c === "S")) ?
 						BEFORE_SPECIAL : IN_TAG_NAME;


### PR DESCRIPTION
This is to ensure that a special ending with a "<" will still be parsed correctly.  Fixes #165
